### PR TITLE
Add note of required Mac OS X Python library

### DIFF
--- a/doc/fontdetect.txt
+++ b/doc/fontdetect.txt
@@ -48,12 +48,24 @@ Then, re-generate your help tags with Vim's |:helptags| command, e.g.: >
 
   :helptags ~/.vim/doc
 
-You may also install fontdetect using a tool like pathogen[1] by unpacking
+You may also install |fontdetect| using a tool like pathogen[1] by unpacking
 the downloaded archive into a bundle directory, e.g.: >
 
   ~/.vim/bundle/fontdetect
 
 [1]: https://github.com/tpope/vim-pathogen
+
+-------------------------------------------------------------------------------
+2.1   Mac OS X                                      *fontdetect-macosx*
+
+On Mac OS X |fontdetect| utilizes the Cocoa library in Python.  If not using the
+system-supplied Python 2.7 you must install pyobjc-framework-cocoa via pip: >
+
+  pip2 install pyobjc-framework-cocoa
+
+or: >
+
+  pip3 install pyobjc-framework-cocoa
 
 ===============================================================================
 3.  Usage                                           *fontdetect-usage*


### PR DESCRIPTION
Add a subsection to the installation section regarding installing Python libraries for Cocoa support.

If not using the Mac OS X standard Python 2 installation (i.e. using Python installed via Homebrew) `pyobjc-framework-cocoa` needs to be installed for fontdetect to work.  I always forget this fact and the note always helps me.  Figured it might help others!